### PR TITLE
Update to iron-flex-layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,8 +27,11 @@
   "devDependencies": {
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.8.5",
     "iron-selector": "PolymerElements/iron-selector#^0.8.2",
-    "paper-styles": "PolymerElements/paper-styles#^0.8.3",
-    "paper-styles": "PolymerElements/paper-styles#^0.8.6",
+    "paper-styles": "PolymerElements/paper-styles#^0.8.9",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^0.8.1",
     "web-component-tester": "*"
+  },
+  "resolutions": {
+    "observe-js": "0.5.6-rc1"
   }
 }

--- a/demo/polyfora-forum.html
+++ b/demo/polyfora-forum.html
@@ -7,7 +7,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../paper-styles/layout.html">
+<link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../../paper-styles/shadow.html">
 <link rel="import" href="../../paper-styles/typography.html">
 

--- a/demo/polyfora-thread.html
+++ b/demo/polyfora-thread.html
@@ -7,7 +7,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../paper-styles/layout.html">
+<link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../../paper-styles/shadow.html">
 <link rel="import" href="../../paper-styles/typography.html">
 


### PR DESCRIPTION
r: @nevir 

Minimal set of changes needed to get the demos/package working atm. Summary:

* Define resolution for observe-js so you get the correct observe-js.html import
* Update to iron-flex-layout classes otherwise the demos fail out of the box
* Bumps to latest paper-styles