### PR TITLE
Use attrForSelected if specified

### DIFF
--- a/more-route-selector.html
+++ b/more-route-selector.html
@@ -142,8 +142,15 @@ Polymer({
 
   _onMoreRouteChange: function(event) {
     if (!this._managedSelector) return;
-    var route = event.detail.newRoute;
-    this._managedSelector.select(this.routes.indexOf(route));
+    var index = this.routes.indexOf(event.detail.newRoute);
+    var selected;
+    if (this._managedSelector.attrForSelected) {
+      selected = this._managedSelector.items[index].getAttribute(
+          this._managedSelector.attrForSelected);
+    } else {
+      selected = index;
+    }
+    this._managedSelector.select(selected);
   },
 
   _findTargetSelector: function() {


### PR DESCRIPTION
more-routing always sets the selector's `selected` property to the index of the route, which doesn't work when the selector has specified a string for `attrForSelected`.

I'd like this to be released in 0.8 but I'm not sure how to go about requesting that when the upstream doesn't have a branch for it.