### PR TITLE
Fix TypeError bug when this.route is null

### DIFF
--- a/more-route.html
+++ b/more-route.html
@@ -132,10 +132,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _routeChanged: function() {
       this._observeRoute();
-      this._setFullPath(this.route.fullPath);
-      // this._setParams(this.route.params);
-      this.params = this.route.params;
-      this._setActive(this.route.active);
+      if (this.route) {
+        this._setFullPath(this.route.fullPath);
+        // this._setParams(this.route.params);
+        this.params = this.route.params;
+        this._setActive(this.route.active);
+      } else {
+        this._setFullPath(null);
+        this.params = null;
+        this._setActive(false);
+      }
 
       // @see MoreRouting.ContextAware
       this.moreRouteContext = this.route;


### PR DESCRIPTION
If `this.route` is `null`, trying to dereference `this.route.fullPath` leads to an uncaught `TypeError`. This error can be easily found when trying to programmatically create an instance of `<more-route>` when it has no parent, as the preconditions in `_identityChanged` for setting `this.route` to `null` are only that `this.name` and `this.path` are both falsy, which is true when the element has just been created with `document.createElement('more-route')`.

Local test results after patch:
```
Starting Selenium server for local browsers
Selenium server running on port 50417
Web server running on port 50425 and serving from /Users/vartan/Documents/webcomponent-dev/polymer-0.9.x/more-routing
chrome 42                Beginning tests via http://localhost:50425/components/more-routing/generated-index.html?cli_browser_id=0
safari 8.0.6             Beginning tests via http://localhost:50425/components/more-routing/generated-index.html?cli_browser_id=2
chrome 42                Tests passed
safari 8.0.6             Tests passed
firefox 37               Beginning tests via http://localhost:50425/components/more-routing/generated-index.html?cli_browser_id=1
firefox 37               Tests passed
Test run ended with great success

chrome 42 (3/0/0)                       firefox 37 (3/0/0)                    
safari 8.0.6 (3/0/0)  
```