### PR TITLE
Properly encode/decode parameter values

### DIFF
--- a/route.html
+++ b/route.html
@@ -128,7 +128,7 @@ Route.prototype.partsForParams = function partsForParams(params, silent) {
           throw new Error('Missing param "' + config.name + '" for route ' + this);
         }
       }
-      parts.push(value);
+      parts.push(encodeURIComponent(value));
     }
   }
   return parts;
@@ -154,7 +154,7 @@ Route.prototype.processPathParts = function processPathParts(parts) {
     }
     for (var i = 0, config; config = this.compiled[i]; i++) {
       if (config.type === 'param') {
-        this.params[config.name] = parts[i];
+        this.params[config.name] = decodeURIComponent(parts[i]);
       }
     }
   } else {


### PR DESCRIPTION
Allow for path parameters with less trivial values, containing special characters, path-part separators, etc.