### PR TITLE
Initialize the selector's routes asynchronously so that the managed

### DIFF
--- a/more-route-selector.html
+++ b/more-route-selector.html
@@ -117,7 +117,7 @@ Polymer({
 
     this._managedSelector.addEventListener(
         'selected-item-changed', this._onSelectedItemChanged.bind(this));
-    this._updateRoutes();
+    this.async(this._updateRoutes);
   },
 
   /**


### PR DESCRIPTION
selector is ready.

This resolves a broken initialization when using more-route-selector with an attr-for-selected property on the managed selector.
