### PR TITLE
selected* properties are not updated

### DIFF
--- a/more-route-selector.html
+++ b/more-route-selector.html
@@ -21,10 +21,6 @@ TODO(nevir): Support child addition/removal/reorder.
     <more-route-selection
         id="selection"
         routes="[[routes]]"
-        selected-route="{{selectedRoute}}"
-        selected-index="{{selectedIndex}}"
-        selected-path="{{selectedPath}}"
-        selected-params="{{selectedParams}}"
         on-more-route-change="_onMoreRouteChange">
     </more-route-selection>
     <content></content>
@@ -145,7 +141,7 @@ Polymer({
     this._setRoutes(routes);
   },
 
-  _onMoreRouteChange: function(event) {
+  _onMoreRouteChange: function(event, detail) {
     if (!this._managedSelector) return;
 
     var selected = '';
@@ -164,6 +160,12 @@ Polymer({
     this._settingSelection = true;
     this._managedSelector.select(selected);
     this._settingSelection = false;
+    
+    // propogate the changes to this component
+    this._setSelectedRoute(detail.newRoute);
+    this._setSelectedIndex(detail.newIndex);
+    this._setSelectedPath(detail.newPath);
+    this._setSelectedParams(detail.newParams);
   },
 
   _findTargetSelector: function() {


### PR DESCRIPTION
Properties such as selectedParams are not updated on `more-route-selector` although they are updated in `more-route-selection`.

The approach done in commit 357a13051f8137275f386906c0f0361ca49967d1 is wrong and I will be preparing a correct update pull request.