### PR TITLE
Fix bug where route for / would match /path

### DIFF
--- a/route.html
+++ b/route.html
@@ -168,7 +168,7 @@ Route.prototype.processPathParts = function processPathParts(parts) {
 
 Route.prototype.matchesPathParts = function matchesPathParts(parts) {
   if (!parts) return false;
-  if (parts.length < this.compiled.length) return false;
+  if (parts.length !== this.compiled.length) return false;
   for (var i = 0, config; config = this.compiled[i]; i++) {
     if (config.type === 'static' && parts[i] !== config.part) {
       return false;


### PR DESCRIPTION
### Bugged behaviour

Assume `this.path` is `/`. Thus, `this.compiled` is `[]`.

User navigates to `/path`. When running `matchesPathParts(parts)`, the `parts` parameter is `[ 'path' ]`.

`!parts` is false, so the first if-statement has no effect.

The original copy of the second if-statement only checked if `parts.length` was not less than `this.compiled.length`, which in this case is true as `[ 'path' ].length === 1` and `[].length === 0`.

Next, the for-loop instantiates the `i` variable to `0`, and sets `config` to `this.compiled[i]`, which in this case effectively sets `config` to `undefined` as `[][0]` evaluates to `undefined`. This value is falsy, so the for-loop exits without executing its contents.

Finally, the function erroneously returns true, indicating that the route for `/` matches `/path`, which it shouldn't.

### Fix

Instead of only checking if `this.compiled.length` is greater than `parts.length`, using `!==` instead of `<`, which effectively checks whether or not `this.compiled.length` is greater *or* less than `parts.length`.

Thus, for the scenario described above, `/` would not match `/path` because `[ 'path' ].length !== [].length`.