### PR TITLE
Fix #52 and #53 by debouncing the firing of the 'more-route-change' event

### DIFF
--- a/more-route-selection.html
+++ b/more-route-selection.html
@@ -154,12 +154,14 @@ TODO(nevir): Document.
       this._setSelectedPath(newPath);
       this._setSelectedParams(newParams);
 
-      this.fire('more-route-change', {
-        newRoute:  newRoute,  oldRoute:  oldRoute,
-        newIndex:  newIndex,  oldIndex:  oldIndex,
-        newPath:   newPath,   oldPath:   oldPath,
-        newParams: newParams, oldParams: oldParams,
-      });
+      this.debounce('fire-more-route-change', function() {
+        this.fire('more-route-change', {
+          newRoute:  newRoute,  oldRoute:  oldRoute,
+          newIndex:  newIndex,  oldIndex:  oldIndex,
+          newPath:   newPath,   oldPath:   oldPath,
+          newParams: newParams, oldParams: oldParams,
+        });
+      }, 100);
     },
     /**
      * We want the most specific routes to match first, so we must create a

--- a/more-route-selector.html
+++ b/more-route-selector.html
@@ -121,6 +121,7 @@ Polymer({
 
     this._managedSelector.addEventListener(
         'selected-item-changed', this._onSelectedItemChanged.bind(this));
+    this._managedSelector.addEventListener('iron-items-changed', this._updateRoutes.bind(this));
     this._updateRoutes();
   },
 


### PR DESCRIPTION
Fix #52 and #53 by debouncing the firing of the 'more-route-change' event.

Debounce the 'more-route-change’ event to prevent a temporary selection
of the base route `/` if it exists, since it is always considered as
active when a more specific route is selected.
