### PR TITLE
Silent all route param changes during route initialization

### DIFF
--- a/driver.html
+++ b/driver.html
@@ -27,6 +27,10 @@ Driver.prototype.manageRoute = function manageRoute(route) {
   route.driver = this;
   this._appendRoute(route);
 
+  // We don't want to notify of these changes; they might stop
+  // the activation of child routes during initialization
+  route.params.__silent = true;
+
   if (route.parent) {
     if (route.parent.active) {
       // Remember: `processPathParts` takes just the path parts relative to that
@@ -38,6 +42,8 @@ Driver.prototype.manageRoute = function manageRoute(route) {
   }
 
   if (route.active) this._activeRoutes.push(route);
+
+  delete route.params.__silent;
 };
 
 Driver.prototype.urlForParts = function urlForParts(parts) {

--- a/route.html
+++ b/route.html
@@ -144,13 +144,12 @@ Route.prototype.processPathParts = function processPathParts(parts) {
   this.parts  = parts;
   this.active = this.matchesPathParts(parts);
 
-  // We don't want to notify of these changes; they'd be no-op noise.
-  this.params.__silent = true;
-
   if (this.active) {
     var keys = Object.keys(this.params);
     for (var i = 0; i < keys.length; i++) {
-      delete this.params[keys[i]];
+      if (keys[i] !== '__silent') {
+        delete this.params[keys[i]];
+      }
     }
     for (var i = 0, config; config = this.compiled[i]; i++) {
       if (config.type === 'param') {
@@ -162,8 +161,6 @@ Route.prototype.processPathParts = function processPathParts(parts) {
       this.params[key] = undefined;
     }
   }
-
-  delete this.params.__silent;
 };
 
 Route.prototype.matchesPathParts = function matchesPathParts(parts) {


### PR DESCRIPTION
If the param notifies any listener of changes, it will prevent child
routes from activating (when they should).
Fixes #60 