### PR TITLE
more-route-selector had selected* attributes (selectedParam, et al.) not updated to the user because of the 'readOnly' option. Removed. Getting updates now.

### DIFF
--- a/more-route-selector.html
+++ b/more-route-selector.html
@@ -67,7 +67,6 @@ Polymer({
     selectedRoute: {
       type:     Object,
       value:    null,
-      readOnly: true,
       notify:   true,
     },
 
@@ -78,7 +77,6 @@ Polymer({
     selectedIndex: {
       type:     Number,
       value:    -1,
-      readOnly: true,
       notify:   true,
     },
 
@@ -87,7 +85,6 @@ Polymer({
      */
     selectedPath: {
       type:     String,
-      readOnly: true,
       notify:   true,
     },
 
@@ -96,7 +93,6 @@ Polymer({
      */
     selectedParams: {
       type:     Object,
-      readOnly: true,
       notify:   true,
     },
 


### PR DESCRIPTION
Latest commit 0df996eb2a564d330860b225b0be6148ab3fc1cd was correctly adding the selected* attributes from inner more-route-selection to be updated.

Although, the fact that they are 'readOnly' was still blocking the update. 
Removed. Updates are now triggered. 

Potentially closes #72 and #45  